### PR TITLE
test: add OpenAI integration tests

### DIFF
--- a/tests/text/text-openai-structured-output.int.test.ts
+++ b/tests/text/text-openai-structured-output.int.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Lang, z } from '../../dist/index.js';
+
+// Requires OPENAI_API_KEY and internet access
+
+const apiKey = process.env.OPENAI_API_KEY;
+const runTests = apiKey !== undefined;
+
+describe('Structured output with OpenAI (integration)', () => {
+  beforeAll(() => {
+    if (!runTests) {
+      console.warn('Skipping OpenAI structured output test: OPENAI_API_KEY not set');
+    }
+  });
+
+  it('validates returned object against schema', async () => {
+    if (!runTests) return;
+
+    const lang = Lang.openai({ apiKey });
+    const schema = z.object({
+      name: z.string(),
+      age: z.number().int().nonnegative(),
+    });
+
+    const res = await lang.askForObject('Give a random person name and age', schema);
+
+    expect(res.object).not.toBeNull();
+    expect(res.validationErrors).toEqual([]);
+  });
+});
+

--- a/tests/tools/tools-openai.int.test.ts
+++ b/tests/tools/tools-openai.int.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Lang } from '../../dist/index.js';
+
+// Requires OPENAI_API_KEY and internet access
+
+const apiKey = process.env.OPENAI_API_KEY;
+const runTests = apiKey !== undefined;
+
+describe('OpenAI tool calling (integration)', () => {
+  beforeAll(() => {
+    if (!runTests) {
+      console.warn('Skipping OpenAI tool test: OPENAI_API_KEY not set');
+    }
+  });
+
+  it('returns tool call with arguments', async () => {
+    if (!runTests) return;
+
+    const lang = Lang.openai({ apiKey });
+    const result = await lang.chat(
+      [
+        {
+          role: 'user',
+          content:
+            'Use the get_weather tool to fetch the weather for Boston in celsius. Only call the tool.'
+        }
+      ],
+      {
+        tools: [
+          {
+            name: 'get_weather',
+            description: 'Get weather by location',
+            parameters: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+                unit: { type: 'string', enum: ['c', 'f'] }
+              },
+              required: ['location']
+            }
+          }
+        ]
+      }
+    );
+
+    expect(result.tools).toBeDefined();
+    expect(result.tools![0].name).toBe('get_weather');
+    expect(result.tools![0].arguments.location.toLowerCase()).toContain('boston');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add OpenAI tool-calling integration test
- add OpenAI structured-output integration test

## Testing
- `npm run build`
- `OPENAI_API_KEY=**** npx vitest run tests/tools/tools-openai.int.test.ts tests/text/text-openai-structured-output.int.test.ts` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d54cd0c2483338ccd0f52711b27f1