### PR TITLE
Complete openai responses for streaming and non-streaming

### DIFF
--- a/src/lang/process-lines-from-stream.ts
+++ b/src/lang/process-lines-from-stream.ts
@@ -10,20 +10,31 @@ const processLinesFromStream = (rawData: string, onData: (data: any) => void) =>
 
 const processDataAsStr = (rawData: string, onData: (data: any) => void) => {
   const lines = rawData.split("\n");
+  let currentEvent: string | null = null;
   for (const line of lines) {
+    if (line.startsWith("event: ")) {
+      currentEvent = line.substring(7).trim();
+      continue;
+    }
     if (line.startsWith("data: ")) {
       const dataStr = line.substring(6);
       // @TODO: at the moment it's OpenAI specific. Make it generic.
       if (dataStr === "[DONE]") {
         onData({ finished: true });
-        return;
+        currentEvent = null;
+        continue;
       }
 
       try {
         const data = JSON.parse(dataStr);
+        if (currentEvent && typeof data === 'object' && data !== null && !('type' in data)) {
+          (data as any).type = currentEvent;
+        }
         onData(data);
       } catch (err) {
-        throw new Error(err);
+        throw new Error(err as any);
+      } finally {
+        currentEvent = null;
       }
     }
   }


### PR DESCRIPTION
Add comprehensive support for OpenAI Responses API, handling both streaming and non-streaming outputs, including tool calls, to pass `basic-lang.test.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-41871a3c-011d-4574-ab99-b30495149486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41871a3c-011d-4574-ab99-b30495149486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

